### PR TITLE
bump sharelatex to version 5.0.2-RC4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # based on the work from rigon (https://github.com/rigon/docker-sharelatex-full)
-FROM sharelatex/sharelatex:5.0.1
+FROM sharelatex/sharelatex:5.0.2-RC4
 
 SHELL ["/bin/bash", "-cx"]
 


### PR DESCRIPTION
There is problems with Overleaf version 5.0.1. See #49 and the [Overleaf Release Notes](https://github.com/overleaf/overleaf/wiki/Release-Notes-5.x.x#server-pro-501-retracted).