### PR TITLE
Bump sharelatex image to 5.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # based on the work from rigon (https://github.com/rigon/docker-sharelatex-full)
-FROM sharelatex/sharelatex:5.0.2-RC4
+FROM sharelatex/sharelatex:5.0.3
 
 SHELL ["/bin/bash", "-cx"]
 


### PR DESCRIPTION
Apparently there have been problems with 5.0.2 once again. Maybe this version will stay up for longer?